### PR TITLE
fix: wrong timestamps on guild join

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
 
   db:
     container_name: dumpus-db
-    image: postgres:latest
+    image: postgres:17-alpine
     ports:
       - "${POSTGRES_PORT}:5432"
 

--- a/src/util.py
+++ b/src/util.py
@@ -74,7 +74,11 @@ def count_dates_hours(timestamps):
     # Convert list of timestamps to a pandas Series
     timestamps_series = pd.Series(timestamps)
     # Convert timestamps to datetime and floor to nearest hour
-    timestamps_hour = pd.to_datetime(timestamps_series).dt.floor('H')
+    # Handle both Unix timestamps (numeric) and datetime strings
+    if pd.api.types.is_numeric_dtype(timestamps_series):
+        timestamps_hour = pd.to_datetime(timestamps_series, unit='s').dt.floor('H')
+    else:
+        timestamps_hour = pd.to_datetime(timestamps_series).dt.floor('H')
     # Count occurrences of each unique hour
     date_hour_counts = timestamps_hour.value_counts().to_dict()
     return date_hour_counts

--- a/src/util.py
+++ b/src/util.py
@@ -58,39 +58,37 @@ def ts_included_in_range (ts, start_date, end_date):
     else:
         return start_date <= ts <= end_date
 
-def get_ts_string_parser(line):
-    year, month, day = int(line[1:5]), int(line[6:8]), int(line[9:11])
-    hour, minute = int(line[12:14]), int(line[15:17])
+def get_ts_string_parser(line, start_offset=1):
+    """
+    Parse a timestamp string in format YYYY-MM-DDTHH:MM or similar
+    Use start_offset to skip the leading quote if present
+    """
+    year, month, day = int(line[start_offset:start_offset+4]), int(line[start_offset+5:start_offset+7]), int(line[start_offset+8:start_offset+10])
+    hour, minute = int(line[start_offset+11:start_offset+13]), int(line[start_offset+14:start_offset+16])
 
     return datetime(year=year, month=month, day=day, hour=hour, minute=minute)
 
 def get_ts_regular_string_parser(line):
-    year, month, day = int(line[0:4]), int(line[5:7]), int(line[8:10])
-    hour, minute = int(line[11:13]), int(line[14:16])
+    """Parse timestamp string starting at index 0 (no leading quote)"""
+    return get_ts_string_parser(line, start_offset=0)
 
-    return datetime(year=year, month=month, day=day, hour=hour, minute=minute)
+def _count_dates(timestamps, period='H'):
+    """
+    Count timestamp occurrences grouped by time period
+    Use period to group by hour or day
+    """
+    timestamps_series = pd.Series(timestamps)
+    if pd.api.types.is_numeric_dtype(timestamps_series):
+        timestamps_period = pd.to_datetime(timestamps_series, unit='s').dt.floor(period)
+    else:
+        timestamps_period = pd.to_datetime(timestamps_series).dt.floor(period)
+    return timestamps_period.value_counts().to_dict()
 
 def count_dates_hours(timestamps):
-    # Convert list of timestamps to a pandas Series
-    timestamps_series = pd.Series(timestamps)
-    # Convert timestamps to datetime and floor to nearest hour
-    # Handle both Unix timestamps (numeric) and datetime strings
-    if pd.api.types.is_numeric_dtype(timestamps_series):
-        timestamps_hour = pd.to_datetime(timestamps_series, unit='s').dt.floor('H')
-    else:
-        timestamps_hour = pd.to_datetime(timestamps_series).dt.floor('H')
-    # Count occurrences of each unique hour
-    date_hour_counts = timestamps_hour.value_counts().to_dict()
-    return date_hour_counts
+    return _count_dates(timestamps, period='H')
 
 def count_dates_day(timestamps):
-    # Convert list of timestamps to a pandas Series
-    timestamps_series = pd.Series(timestamps)
-    # Convert timestamps to datetime and floor to nearest hour
-    timestamps_day = pd.to_datetime(timestamps_series, unit='s').dt.floor('D')
-    # Count occurrences of each unique hour
-    date_hour_counts = timestamps_day.value_counts().to_dict()
-    return date_hour_counts
+    return _count_dates(timestamps, period='D')
 
 current_jwt = None
 def generate_diswho_jwt():


### PR DESCRIPTION
the guild_joined event was not represented internally by the same timestamp instance as the rest of the events - they are represented by floats, which have 4 less digits than expected, leading to the date being interpreted in 1970.

this PR implements handling of those timestamps in the common util functions rather than at the event level, reducing the potential similar errors from other events along the way. 

python not having types makes this hard to troubleshoot. i wasn't expecting to go very deep on this specific issue, so this PR works and will definitely help, but i believe that more changes on the parsing side could come in handy towards making parsing accurate and stable.

this PR also fixes the compose definition failing on initial install because of a postgres 18 change. i pinned the container to v17 so that it doesn't complain and endlessly restart. not the most ideal solution, but it works (see commit desc)