### PR TITLE
fix(ci): repair sqlite-docs workflow (openai v1 + bash + actions)

### DIFF
--- a/.github/workflows/sqlite_documentation_gen.yml
+++ b/.github/workflows/sqlite_documentation_gen.yml
@@ -1,4 +1,4 @@
-name: ChatGPT Workflow
+name: SQLite docs auto-generate
 
 on:
   push:
@@ -9,59 +9,73 @@ on:
 jobs:
   update-readme:
     runs-on: ubuntu-latest
+    # Only regenerate docs when the commit asks for it explicitly, or when the
+    # workflow is triggered manually. Otherwise the job is skipped (gray, not red).
+    if: ${{ github.event_name == 'workflow_dispatch' || contains(github.event.head_commit.message, '--rebuild-docs') }}
 
     steps:
-      - name: Check for rebuild-docs
-        run: |
-          echo "Commit message: '${{ steps.commit.outputs.message }}'"
-          if [[ "${{ steps.commit.outputs.message }}" == *"--rebuild-docs"* ]]; then
-            echo "Commit message contains --rebuild-docs. Continue to next step."
-          else
-            echo "Commit message does not contain --rebuild-docs. Skipping subsequent steps."
-            exit 78
-        shell: bash
-        continue-on-error: true
-
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.11'
 
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install openai
+          pip install 'openai>=1.0,<2'
 
-      - name: Read tasks.py and Generate README
-        run: |
-          python -c "
-          import openai
-          import os
-          # Read content
-          with open('src/tasks.py', 'r') as file:
-              lines = file.readlines()
-          start_line = next(i for i, line in enumerate(lines, start=1) if '# auto-generated SQLite documentation starts here' in line)
-          content = ''.join(lines[start_line-1:])
-
-          # Call to ChatGPT
-          openai.api_key = os.getenv('OPENAI_API_KEY')
-          prompt = content
-          response = openai.ChatCompletion.create(model='gpt-4', messages=[{'role': 'user', 'content': f'{prompt}\nGenerate a documentation markdown table for each table of the SQLite database (including package_data). For example:\n\n**activity table**\n|Column|Description\n|event_name|One sentence to explain to the developers what kind of data they will find here. If the code provided allows you to provide an example of data format or value that is great, but do not invent anything.|same for this column|etc.\n\n**Table 2**\n|Column|Description|...\n\netc.'}])
-          readme_content = response.choices[0].message.content.strip()
-
-          # Write to db_doc.md
-          with open('docs/sqlite_database_structure.md', 'w') as file:
-              readme_content = 'Note: this documentation was generated automatically from the tasks.py code using an AI. Although we are confident in the reliability of the data displayed here, errors may occur.\n\n\n' + readme_content 
-              file.write(readme_content)
-          "
+      - name: Generate SQLite docs
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          python <<'PY'
+          from openai import OpenAI
+
+          with open('src/tasks.py', 'r') as f:
+              lines = f.readlines()
+          start_line = next(
+              i for i, line in enumerate(lines, start=1)
+              if '# auto-generated SQLite documentation starts here' in line
+          )
+          content = ''.join(lines[start_line - 1:])
+
+          client = OpenAI()
+          response = client.chat.completions.create(
+              model='gpt-4o-mini',
+              messages=[{
+                  'role': 'user',
+                  'content': (
+                      f'{content}\n'
+                      'Generate a documentation markdown table for each table of the '
+                      'SQLite database (including package_data). For example:\n\n'
+                      '**activity table**\n'
+                      '|Column|Description\n'
+                      '|event_name|One sentence to explain to the developers what kind '
+                      'of data they will find here. If the code provided allows you to '
+                      'provide an example of data format or value that is great, but do '
+                      'not invent anything.|same for this column|etc.\n\n'
+                      '**Table 2**\n'
+                      '|Column|Description|...\n\n'
+                      'etc.'
+                  )
+              }],
+          )
+          readme_content = response.choices[0].message.content.strip()
+
+          header = (
+              'Note: this documentation was generated automatically from the tasks.py '
+              'code using an AI. Although we are confident in the reliability of the '
+              'data displayed here, errors may occur.\n\n\n'
+          )
+          with open('docs/sqlite_database_structure.md', 'w') as f:
+              f.write(header + readme_content)
+          PY
 
       - name: Commit and Push
-        uses: EndBug/add-and-commit@v7
+        uses: EndBug/add-and-commit@v9
         with:
           message: 'Update sqlite_database_structure.md'
           add: 'docs/sqlite_database_structure.md'


### PR DESCRIPTION
## Summary

The repo's only workflow (`sqlite_documentation_gen.yml`, displayed as \"ChatGPT Workflow\") has been red on every run since 2025-06. Two structural breaks plus stale action versions:

1. **Bash syntax error.** The first step's `if/else` had no closing `fi`. `continue-on-error: true` was hiding the failure but the gate never actually worked.
2. **OpenAI SDK v1 break.** The script calls `openai.ChatCompletion.create(...)`, removed in `openai>=1.0` (Nov 2023). Since `pip install openai` is unpinned, v1 installs and immediately raises `AttributeError`.
3. `actions/checkout@v2`, `actions/setup-python@v2`, `EndBug/add-and-commit@v7` all run on Node 12, which GitHub deprecated.

## Changes

- Replace the broken bash gate with a job-level `if:` (`workflow_dispatch` OR `--rebuild-docs` in the commit message). Non-rebuild pushes now show as **skipped (gray)** rather than red.
- Migrate the script to the `openai>=1.0` client API (`OpenAI()` + `client.chat.completions.create`).
- Pin `openai>=1.0,<2` so the next major SDK bump can't quietly break this again.
- Bump deprecated actions: checkout v4, setup-python v5, add-and-commit v9.
- Pin Python to `3.11`.
- Default model `gpt-4o-mini` (cheaper, current). Easy revert to `gpt-4` if preferred.

## Validation

- `yaml.safe_load` of the file: OK
- `ast.parse` of the embedded Python: OK
- `openai>=1.0` SDK surface (`client.chat.completions.create`): OK

## Required after merge

The `OPENAI_API_KEY` repo secret needs to be (re)set with a valid key. Manual `workflow_dispatch` from the Actions tab is the easiest way to confirm end-to-end.

## Test plan

- [ ] Set `OPENAI_API_KEY` repo secret to a valid key
- [ ] Manually trigger via Actions → \"SQLite docs auto-generate\" → Run workflow
- [ ] Confirm `docs/sqlite_database_structure.md` gets a fresh commit from `EndBug/add-and-commit`
- [ ] Push a `tasks.py` change with `--rebuild-docs` in the commit message and verify it triggers; verify a normal push shows skipped (gray)

🤖 Generated with [Claude Code](https://claude.com/claude-code)