### PR TITLE
fix: guard null avatar in get_avatar endpoint

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -290,8 +290,9 @@ def get_avatar(package_id, user_id):
         if not user:
             return make_response('', 500)
         
-        avatar_extension = 'avatar' in user and user['avatar'].startswith('a_') and 'gif' or 'webp'
-        avatar_url = 'avatar' in user and f'https://cdn.discordapp.com/avatars/{user_id}/{user["avatar"]}.{avatar_extension}' or None
+        avatar_hash = user.get('avatar')
+        avatar_extension = 'gif' if avatar_hash and avatar_hash.startswith('a_') else 'webp'
+        avatar_url = f'https://cdn.discordapp.com/avatars/{user_id}/{avatar_hash}.{avatar_extension}' if avatar_hash else None
 
         return jsonify({
             'user_id': user_id,


### PR DESCRIPTION
## Why

Discord's API returns \`{\"avatar\": null}\` for users without a custom avatar. The previous \`'avatar' in user and user['avatar'].startswith('a_')\` only checked key existence, not the value, so \`None.startswith()\` raised \`AttributeError\` on every such user. Visible in production logs as repeated \`/process/{pkg}/user/{id}\` 500s.

## Fix

\`.get('avatar')\` + ternary; \`avatar_url\` falls through to \`None\` when no hash is set, mirroring the pattern \`util.py:46\` already uses in \`generate_avatar_url_from_user_id_avatar_hash\`.

Same class of bug as dumpus-app#357 (and 6 duplicate reports), fixed there in v1.0.5.