### PR TITLE
ci: add infra workflow file to main

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -1,0 +1,68 @@
+name: infra
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        type: choice
+        description: "What to do"
+        options: [plan, apply]
+        default: plan
+
+permissions:
+  contents: read
+
+jobs:
+  infra:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: infra/terraform
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up OpenTofu
+        uses: opentofu/setup-opentofu@v1
+        with:
+          tofu_version: 1.8.5
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-access-key-id: ${{ secrets.BOOTSTRAP_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.BOOTSTRAP_AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-3
+
+      - name: tofu init
+        run: tofu init
+
+      - name: tofu plan
+        if: inputs.action == 'plan'
+        env:
+          TF_VAR_discord_secret: ${{ secrets.DISCORD_SECRET }}
+          TF_VAR_diswho_jwt_secret: ${{ secrets.DISWHO_JWT_SECRET }}
+          TF_VAR_wh_url: ${{ secrets.WH_URL }}
+        run: tofu plan -var-file=terraform.ci.tfvars -no-color | tee /tmp/plan.txt
+
+      - name: tofu apply
+        if: inputs.action == 'apply'
+        env:
+          TF_VAR_discord_secret: ${{ secrets.DISCORD_SECRET }}
+          TF_VAR_diswho_jwt_secret: ${{ secrets.DISWHO_JWT_SECRET }}
+          TF_VAR_wh_url: ${{ secrets.WH_URL }}
+        run: tofu apply -auto-approve -var-file=terraform.ci.tfvars
+
+      - name: Outputs
+        if: inputs.action == 'apply'
+        run: |
+          {
+            echo "## Terraform outputs"
+            echo
+            echo '```'
+            tofu output
+            echo '```'
+            echo
+            echo "**Next**: copy \`github_deploy_role_arn\` into the \`AWS_DEPLOY_ROLE_ARN\` repo secret so the deploy workflow can use OIDC."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -41,7 +41,6 @@ jobs:
       - name: tofu plan
         if: inputs.action == 'plan'
         env:
-          TF_VAR_discord_secret: ${{ secrets.DISCORD_SECRET }}
           TF_VAR_diswho_jwt_secret: ${{ secrets.DISWHO_JWT_SECRET }}
           TF_VAR_wh_url: ${{ secrets.WH_URL }}
         run: tofu plan -var-file=terraform.ci.tfvars -no-color | tee /tmp/plan.txt
@@ -49,7 +48,6 @@ jobs:
       - name: tofu apply
         if: inputs.action == 'apply'
         env:
-          TF_VAR_discord_secret: ${{ secrets.DISCORD_SECRET }}
           TF_VAR_diswho_jwt_secret: ${{ secrets.DISWHO_JWT_SECRET }}
           TF_VAR_wh_url: ${{ secrets.WH_URL }}
         run: tofu apply -auto-approve -var-file=terraform.ci.tfvars

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.BOOTSTRAP_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.BOOTSTRAP_AWS_SECRET_ACCESS_KEY }}
-          aws-region: eu-west-3
+          aws-region: eu-west-1
 
       - name: tofu init
         run: tofu init


### PR DESCRIPTION
## Summary
- Adds \`.github/workflows/infra.yml\` so \`gh workflow run infra.yml\` (which requires the workflow to exist on the default branch) can dispatch it.
- All the Terraform code, tfvars, and IAM bits the workflow consumes live on #54. This PR is purely the workflow file.

## Why split out
\`gh workflow run\` against \`feat/aws-lambda-deploy\` returns 404 because GitHub's workflow_dispatch API only enumerates workflows from the default branch. Landing this file on main first lets us dispatch the workflow with \`--ref feat/aws-lambda-deploy\` to apply the infra from that branch — and avoids merging the big PR before the infra is up.

## Test plan
- [ ] After merge: \`gh workflow run infra.yml -f action=plan --ref feat/aws-lambda-deploy\` resolves and runs.