### PR TITLE
fix(tf): grant lambda:GetFunctionConfiguration to the deploy role

### DIFF
--- a/infra/terraform/github_oidc.tf
+++ b/infra/terraform/github_oidc.tf
@@ -86,6 +86,7 @@ data "aws_iam_policy_document" "github_deploy" {
     actions = [
       "lambda:UpdateFunctionCode",
       "lambda:GetFunction",
+      "lambda:GetFunctionConfiguration",
       "lambda:PublishVersion",
       "lambda:UpdateAlias",
       "lambda:GetAlias",


### PR DESCRIPTION
## Summary
\`aws lambda wait function-updated\` polls \`GetFunctionConfiguration\`, which the OIDC deploy role didn't have. First production deploy failed at the wait step (after the image was already pushed and updated). Patched the policy out-of-band to unblock the deploy; this commit encodes the fix in Terraform so the next \`tofu apply\` doesn't revert it.

## Test plan
- [ ] After merge: trigger \`infra.yml apply\` — should be a 0-change apply for the IAM policy (TF now matches the manual patch).
- [ ] Subsequent push-to-main deploys finish without manual intervention.