### PR TITLE
feat: serve demo via /blob (lazy seed to S3)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -235,28 +235,41 @@ def get_package_data(package_id):
 
 @app.route('/process/<package_id>/blob', methods=['GET'])
 def get_package_blob(package_id):
-    """Return a presigned S3 URL the client can fetch the encrypted blob from.
+    """Return a presigned S3 URL the client can fetch the package blob from.
 
-    Pairs with /data: same auth, same lookup, but instead of streaming the
-    decrypted SQLite through API Gateway (slow + 6MB cap), the client
-    downloads encrypted bytes directly from S3 and decrypts them locally
+    Replaces /data. The client downloads bytes directly from S3 (fast, no
+    API Gateway middleman) and — for real packages — decrypts them locally
     using its UPN.
 
-    Response: {"url": <presigned GET>, "iv": <hex>, "ttl": <seconds>}
-    Errors: 401 (bad bearer), 404 (no row), 409 (row exists but no S3 blob).
+    Response: {"url": <presigned GET>, "iv": <hex|null>, "ttl": <seconds>}
+              iv is null for the demo (the demo blob is unencrypted).
+
+    Errors: 401 (bad bearer), 404 (no row / no S3 blob), 501 (S3 not wired).
     """
     import os
     import blob_storage
     from db import SavedPackageData
 
+    if not blob_storage.is_enabled():
+        # /blob requires S3. Local dev should use /data.
+        return jsonify({'errorMessageCode': 'S3_NOT_CONFIGURED'}), 501
+
+    ttl = int(os.getenv('PACKAGE_DATA_PRESIGNED_URL_TTL_SECONDS', '300'))
+
+    # Demo: unauthenticated, lazy-seed S3 from generate_demo_database() on the
+    # very first call after deploy, then serve from S3 forever after.
+    if package_id == 'demo':
+        if not blob_storage.exists('demo'):
+            blob_storage.upload('demo', generate_demo_database())
+        return jsonify({
+            'url': blob_storage.presigned_url('demo', ttl_seconds=ttl),
+            'iv': None,
+            'ttl': ttl,
+        }), 200
+
     (is_auth, _) = check_authorization_bearer(request, package_id)
     if not is_auth:
         return make_response('', 401)
-
-    if not blob_storage.is_enabled():
-        # /blob is meaningless without S3 — fall through so callers can
-        # detect and switch back to /data.
-        return jsonify({'errorMessageCode': 'S3_NOT_CONFIGURED'}), 501
 
     session = Session()
     row = session.query(SavedPackageData).filter_by(package_id=package_id).order_by(
@@ -264,22 +277,18 @@ def get_package_blob(package_id):
     ).first()
     session.close()
 
-    if not row:
+    if not row or not blob_storage.exists(package_id):
         return make_response('', 404)
-
-    if not blob_storage.exists(package_id):
-        # Row exists in DB but worker hadn't migrated yet (or upload failed).
-        # Caller can fall back to /data.
-        return jsonify({'errorMessageCode': 'BLOB_NOT_IN_S3'}), 409
-
-    ttl = int(os.getenv('PACKAGE_DATA_PRESIGNED_URL_TTL_SECONDS', '300'))
-    url = blob_storage.presigned_url(package_id, ttl_seconds=ttl)
 
     iv_value = row.iv
     if isinstance(iv_value, (bytes, bytearray)):
         iv_value = iv_value.hex()
 
-    return jsonify({'url': url, 'iv': iv_value, 'ttl': ttl}), 200
+    return jsonify({
+        'url': blob_storage.presigned_url(package_id, ttl_seconds=ttl),
+        'iv': iv_value,
+        'ttl': ttl,
+    }), 200
 
 
 @app.route('/process/<package_id>', methods=['DELETE'])

--- a/src/blob_storage.py
+++ b/src/blob_storage.py
@@ -24,14 +24,15 @@ def _key(package_id: str) -> str:
     return f"packages/{package_id}.bin"
 
 
-def upload_encrypted(package_id: str, encrypted_bytes: bytes) -> None:
-    """Push the encrypted blob to S3 under a deterministic key."""
+def upload(package_id: str, body: bytes) -> None:
+    """Push a blob to S3 under a deterministic key. Same operation for the
+    worker's encrypted SQLite and the demo's unencrypted one."""
     import boto3
 
     boto3.client("s3").put_object(
         Bucket=_bucket(),
         Key=_key(package_id),
-        Body=encrypted_bytes,
+        Body=body,
         ContentType="application/octet-stream",
     )
 

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -882,7 +882,7 @@ def read_analytics_file(package_status_id, package_id, link, session):
     import blob_storage
     if blob_storage.is_enabled():
         try:
-            blob_storage.upload_encrypted(package_id, data)
+            blob_storage.upload(package_id, data)
         except Exception as e:
             print(f'WARN: S3 blob upload failed for {package_id}: {e}')
 


### PR DESCRIPTION
## Summary
The previous S3 PR (#57) only updated the worker code path. Demo doesn't go through the worker — it's generated lazily inside the API — so /demo/data was still hitting API Gateway's slow binary-response path (~25s for 370KB).

This PR puts demo handling in /blob (the new endpoint) instead of /data (the one we'll deprecate once the frontend migrates). First call to /blob/demo after a fresh deploy lazy-seeds S3 from generate_demo_database(); every call after that is just a presigned-URL lookup.

## Changes
- /blob/demo: no auth, lazy-seeds S3, returns \`{url, iv: null, ttl}\`
- /blob/<real package>: unchanged (auth + DB row + presigned URL with iv as hex)
- /data fully untouched — still serves demo/real packages the slow way for legacy clients
- blob_storage.upload() replaces the misleadingly-named upload_encrypted; worker call site updated

## Test plan
- [ ] After deploy: \`curl https://api.dumpus.app/process/demo/blob\` returns JSON with a presigned URL and iv=null
- [ ] First call slow (~3s — generates SQLite + uploads to S3 + signs URL); subsequent calls fast (~200ms — just signs)
- [ ] \`curl -L $url\` from the response downloads a valid SQLite at S3 speeds
- [ ] /data?package=demo still works exactly as before (legacy path)