### PR TITLE
fix(iam): API role needs s3:PutObject for demo lazy-seed

### DIFF
--- a/infra/terraform/iam.tf
+++ b/infra/terraform/iam.tf
@@ -44,10 +44,14 @@ data "aws_iam_policy_document" "api" {
 
   # boto3.generate_presigned_url signs with this role's identity, so the
   # role itself must be allowed to GetObject — the URL just borrows that
-  # permission for ~5 minutes.
+  # permission for ~5 minutes. PutObject is for the demo lazy-seed path
+  # in /blob/demo (the worker uploads real packages with its own role).
   statement {
-    sid       = "ReadPackageBlobs"
-    actions   = ["s3:GetObject"]
+    sid = "ReadWritePackageBlobs"
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+    ]
     resources = ["${aws_s3_bucket.package_data.arn}/*"]
   }
 


### PR DESCRIPTION
/blob/demo on a fresh deploy uploads the generated SQLite to S3 from the API Lambda; the role only had GetObject so the put failed.