### PR TITLE
fix(blob): regional S3 endpoint to avoid CORS-blocking redirects

### DIFF
--- a/src/blob_storage.py
+++ b/src/blob_storage.py
@@ -24,12 +24,27 @@ def _key(package_id: str) -> str:
     return f"packages/{package_id}.bin"
 
 
+def _client():
+    """boto3 S3 client pinned to the function's region with sigv4.
+
+    Without these, boto3 generates URLs like `bucket.s3.amazonaws.com`
+    which 308-redirect to the regional endpoint for non-us-east-1 buckets.
+    Browsers treat the redirect as cross-origin and CORS-block the response.
+    """
+    import boto3
+    from botocore.config import Config
+
+    return boto3.client(
+        "s3",
+        region_name=os.environ.get("AWS_REGION", "eu-west-1"),
+        config=Config(signature_version="s3v4"),
+    )
+
+
 def upload(package_id: str, body: bytes) -> None:
     """Push a blob to S3 under a deterministic key. Same operation for the
     worker's encrypted SQLite and the demo's unencrypted one."""
-    import boto3
-
-    boto3.client("s3").put_object(
+    _client().put_object(
         Bucket=_bucket(),
         Key=_key(package_id),
         Body=body,
@@ -39,9 +54,7 @@ def upload(package_id: str, body: bytes) -> None:
 
 def presigned_url(package_id: str, ttl_seconds: int = 300) -> str:
     """Return a short-lived URL the client can GET directly from S3."""
-    import boto3
-
-    return boto3.client("s3").generate_presigned_url(
+    return _client().generate_presigned_url(
         "get_object",
         Params={"Bucket": _bucket(), "Key": _key(package_id)},
         ExpiresIn=ttl_seconds,
@@ -50,11 +63,10 @@ def presigned_url(package_id: str, ttl_seconds: int = 300) -> str:
 
 def exists(package_id: str) -> bool:
     """True if a blob has been uploaded for this package."""
-    import boto3
     from botocore.exceptions import ClientError
 
     try:
-        boto3.client("s3").head_object(Bucket=_bucket(), Key=_key(package_id))
+        _client().head_object(Bucket=_bucket(), Key=_key(package_id))
         return True
     except ClientError as e:
         # boto3 reports object-not-found in several flavors depending on the


### PR DESCRIPTION
Browser-side download from the presigned URL was getting CORS-blocked because S3 redirects bucket.s3.amazonaws.com → bucket.s3.eu-west-1.amazonaws.com and that redirect is cross-origin. Pin region+sigv4 in boto3 so the URL is regional from the start.