### PR TITLE
feat: /widget endpoint to replace widget.dumpus.app

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -43,6 +43,7 @@ jobs:
         env:
           TF_VAR_diswho_jwt_secret: ${{ secrets.DISWHO_JWT_SECRET }}
           TF_VAR_wh_url: ${{ secrets.WH_URL }}
+          TF_VAR_discord_bot_token: ${{ secrets.DISCORD_BOT_TOKEN }}
         run: tofu plan -var-file=terraform.ci.tfvars -no-color | tee /tmp/plan.txt
 
       - name: tofu apply
@@ -50,6 +51,7 @@ jobs:
         env:
           TF_VAR_diswho_jwt_secret: ${{ secrets.DISWHO_JWT_SECRET }}
           TF_VAR_wh_url: ${{ secrets.WH_URL }}
+          TF_VAR_discord_bot_token: ${{ secrets.DISCORD_BOT_TOKEN }}
         run: tofu apply -auto-approve -var-file=terraform.ci.tfvars
 
       - name: Outputs

--- a/infra/terraform/iam.tf
+++ b/infra/terraform/iam.tf
@@ -39,6 +39,7 @@ data "aws_iam_policy_document" "api" {
       aws_secretsmanager_secret.postgres_url.arn,
       aws_secretsmanager_secret.diswho_jwt_secret.arn,
       aws_secretsmanager_secret.wh_url.arn,
+      aws_secretsmanager_secret.discord_bot_token.arn,
     ]
   }
 
@@ -106,6 +107,7 @@ data "aws_iam_policy_document" "worker" {
       aws_secretsmanager_secret.postgres_url.arn,
       aws_secretsmanager_secret.diswho_jwt_secret.arn,
       aws_secretsmanager_secret.wh_url.arn,
+      aws_secretsmanager_secret.discord_bot_token.arn,
     ]
   }
 

--- a/infra/terraform/lambda.tf
+++ b/infra/terraform/lambda.tf
@@ -11,9 +11,10 @@ locals {
     # Sensitive values are NOT in env. The Lambda's secrets_loader.py reads
     # them from Secrets Manager at startup using the ARNs below.
     SECRETS_ARN_MAP = jsonencode({
-      POSTGRES_URL      = aws_secretsmanager_secret.postgres_url.arn
-      DISWHO_JWT_SECRET = aws_secretsmanager_secret.diswho_jwt_secret.arn
-      WH_URL            = aws_secretsmanager_secret.wh_url.arn
+      POSTGRES_URL       = aws_secretsmanager_secret.postgres_url.arn
+      DISWHO_JWT_SECRET  = aws_secretsmanager_secret.diswho_jwt_secret.arn
+      WH_URL             = aws_secretsmanager_secret.wh_url.arn
+      DISCORD_BOT_TOKEN  = aws_secretsmanager_secret.discord_bot_token.arn
     })
 
     # Encrypted package blobs live here; API generates presigned URLs.

--- a/infra/terraform/secrets.tf
+++ b/infra/terraform/secrets.tf
@@ -65,3 +65,17 @@ resource "aws_secretsmanager_secret_version" "wh_url" {
     ignore_changes = [secret_string]
   }
 }
+
+resource "aws_secretsmanager_secret" "discord_bot_token" {
+  name                    = "${local.name}/app/discord-bot-token"
+  recovery_window_in_days = 7
+}
+
+resource "aws_secretsmanager_secret_version" "discord_bot_token" {
+  secret_id     = aws_secretsmanager_secret.discord_bot_token.id
+  secret_string = var.discord_bot_token
+
+  lifecycle {
+    ignore_changes = [secret_string]
+  }
+}

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -158,6 +158,13 @@ variable "wh_url" {
   default     = ""
 }
 
+variable "discord_bot_token" {
+  description = "Discord bot token. Used by /widget to fetch guild info via the bot API."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
 variable "diswho_jwt_secret" {
   type      = string
   sensitive = true

--- a/src/app.py
+++ b/src/app.py
@@ -12,7 +12,7 @@ from db import PackageProcessStatus, SavedPackageData, Session, fetch_package_st
 
 from sqlite import generate_demo_database
 
-from util import check_discord_link, check_whitelisted_link, extract_package_id_from_discord_link, extract_package_id_from_upn, fetch_diswho_user
+from util import check_discord_link, check_whitelisted_link, extract_package_id_from_discord_link, extract_package_id_from_upn, fetch_diswho_user, fetch_discord_guild, discord_icon_url
 
 from wh import send_internal_notification
 
@@ -316,6 +316,27 @@ def get_avatar(package_id, user_id):
             'avatar_url': avatar_url,
             'username': user['username'] if 'username' in user and user['username'] else None,
         }), 200
+
+
+@app.route('/widget/<guild_id>', methods=['GET'])
+def get_widget(guild_id):
+    """Replacement for the legacy widget.dumpus.app proxy.
+
+    Returns name + icon_url + member_count for a guild the bot can see.
+    """
+    if not guild_id.isdigit():
+        return jsonify({'error': 'invalid guild id'}), 400
+
+    guild = fetch_discord_guild(guild_id)
+    if not guild:
+        return jsonify({'error': 'guild not found or bot lacks access'}), 404
+
+    return jsonify({
+        'name': guild['name'],
+        'icon_url': discord_icon_url(guild_id, guild.get('icon')),
+        'member_count': guild.get('approximate_member_count', 0),
+    }), 200
+
 
 @app.errorhandler(404)
 def page_not_found(e):

--- a/src/util.py
+++ b/src/util.py
@@ -107,7 +107,7 @@ def fetch_diswho_user(user_id):
         auth = f"Bearer {diswho_jwt}"
     else:
         base_url = os.getenv('DISCORD_BASE_URL', 'https://discord.com/api/v8/users/')
-        auth = f"Bot {os.getenv('DISCORD_SECRET')}"
+        auth = f"Bot {os.getenv('DISCORD_BOT_TOKEN')}"
 
     headers = {
         'authorization': auth
@@ -118,3 +118,26 @@ def fetch_diswho_user(user_id):
         return r.json()
     else:
         return None
+
+
+def fetch_discord_guild(guild_id):
+    """Fetch a guild via the Discord bot API. Returns the parsed JSON or None on error."""
+    bot_token = os.getenv('DISCORD_BOT_TOKEN')
+    if not bot_token:
+        return None
+    r = requests.get(
+        f'https://discord.com/api/v10/guilds/{guild_id}',
+        params={'with_counts': 'true'},
+        headers={'Authorization': f'Bot {bot_token}'},
+        timeout=5,
+    )
+    if r.status_code != 200:
+        return None
+    return r.json()
+
+
+def discord_icon_url(guild_id, icon_hash):
+    if not icon_hash:
+        return None
+    ext = 'gif' if icon_hash.startswith('a_') else 'png'
+    return f'https://cdn.discordapp.com/icons/{guild_id}/{icon_hash}.{ext}'


### PR DESCRIPTION
Drop-in replacement for widget.dumpus.app (currently 502 from the OVH box). Adds DISCORD_BOT_TOKEN to the deployment so the API can call Discord's bot endpoint.