### PR TITLE
fix(security): stop logging the package link (it contains the UPN key)

### DIFF
--- a/src/tasks.py
+++ b/src/tasks.py
@@ -919,7 +919,10 @@ def process_package(package_status_id, package_id, link, worker_name='regular_pr
     worker Lambda in production. worker_name lets premium-only work skip the
     regular-process path; we only run regular_process today.
     """
-    print(f'handling package {package_id} with link {link}')
+    # Don't log the link itself: it ends with ?upn=<UPN>, which is the
+    # AES key for that user's encrypted blob. Logging it would put the
+    # decryption key in CloudWatch.
+    print(f'handling package {package_id}')
     session = Session()
     package_status = session.query(PackageProcessStatus).filter(PackageProcessStatus.id == package_status_id).first()
     if not package_status:


### PR DESCRIPTION
The link printed at the start of `process_package` is `https://click.discord.com/ls/click?upn=<UPN_KEY>`. The UPN is the AES key for the encrypted blob, so it was sitting in CloudWatch in plaintext for 30 days, contradicting the README's claim that the key never reaches the server.

Just drop `link` from the print. package_id alone is enough to correlate log lines.