### PR TITLE
fix(worker): store iv as hex string instead of raw bytes

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -238,13 +238,9 @@ def get_package_blob(package_id):
     if not row or not blob_storage.exists(package_id):
         return make_response('', 404)
 
-    iv_value = row.iv
-    if isinstance(iv_value, (bytes, bytearray)):
-        iv_value = iv_value.hex()
-
     return jsonify({
         'url': blob_storage.presigned_url(package_id, ttl_seconds=ttl),
-        'iv': iv_value,
+        'iv': row.iv,
         'ttl': ttl,
     }), 200
 

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -913,9 +913,12 @@ def read_analytics_file(package_status_id, package_id, link, session):
 
     # Encrypted blob → S3 (clients fetch via presigned URL); only the iv
     # stays in Postgres so the API can hand it to the client for decryption.
+    # Store iv as hex — the column is a String, so writing raw bytes lets
+    # PostgreSQL serialize it as the BYTEA literal "\x..." which leaks
+    # straight to the client.
     import blob_storage
     blob_storage.upload(package_id, data)
-    session.add(SavedPackageData(package_id=package_id, iv=iv))
+    session.add(SavedPackageData(package_id=package_id, iv=iv.hex()))
     session.commit()
 
     print(f'SQLite serialization: {time.time() - start}')


### PR DESCRIPTION
## Summary

The worker was writing \`os.urandom(16)\` (raw bytes) into the \`SavedPackageData.iv\` column, which is declared as \`String(255)\` in db.py:17. SQLAlchemy/psycopg2 serialize bytes-into-text using PostgreSQL's BYTEA literal — \`\\x\` followed by the hex bytes — and that string flowed unchanged to the client through \`/blob\`'s JSON response (\`\"iv\": \"\\\\x5d05...\"\`).

The frontend then handed that to \`decryptPackageBlob\`, which interpreted it as a hex IV. The leading \`\\x\` is not valid hex, so AES-CBC decryption either threw or produced garbage. The loading page hung forever — backend showed \`PROCESSED\`, but the data fetcher never resolved, so the UI stayed on the processing screen.

Spotted because PR #74's first real package finished server-side but the UI reported it as still processing — a curl on \`/blob\` revealed the malformed IV.

## Fix

- **Worker** (\`tasks.py\`): write \`iv.hex()\` instead of \`iv\`. Clean 32-char hex string in the column.
- **API** (\`app.py\`): drop the defensive \`bytes-to-hex\` branch in \`/blob\`. With the worker writing hex directly, \`row.iv\` is always already a string — the defensive code was actually masking the real bug (it only kicked in if the value were bytes, but here it's a string starting with \`\\x\`).

No frontend change. The frontend is correct — it expects a hex string and the server should always provide one.

## Migration

Existing rows written before this fix still carry the \`\\x\` prefix in the \`iv\` column and will continue to fail decryption. To recover them:

\`\`\`bash
scripts/reprocess.sh \"<discord-link>\"
\`\`\`

Reprocessing deletes the bad row + S3 blob and re-runs the worker, which now stores a clean hex IV.

I won't backfill — there's only one such row in production right now (the test package from the Fargate validation), and reprocessing it is a one-liner.

## Test plan

- [ ] Merge → CI deploys (the deploy.yml already updates both Lambdas + the Fargate task definition).
- [ ] Run \`scripts/reprocess.sh\` on the existing test package.
- [ ] Confirm \`/blob\` returns \`iv\` as a clean 32-char hex string (no \`\\x\` prefix).
- [ ] Confirm the loading page advances past \"processing\" and redirects to \`/overview\`.