### PR TITLE
perf(sqlite): add secondary indexes for frontend queries

### DIFF
--- a/src/sqlite.py
+++ b/src/sqlite.py
@@ -26,6 +26,40 @@ def export_sqlite_to_bin(cur, conn):
         return (zipped_buffer)
     
 
+def create_indexes(cur):
+    """Add secondary indexes used by the frontend's read queries.
+
+    Built once after bulk inserts (rather than declared in CREATE TABLE)
+    so each insert only writes the row, and the index is constructed in
+    one shot at the end. This keeps worker write time down on heavy
+    packages.
+
+    The picks below were chosen against the queries actually run by the
+    frontend (see hooks/data/use-*.ts in dumpus-app):
+
+    - activity: every read filters on event_name + a date range, often
+      narrowed by guild or channel. The existing PK starts with
+      (event_name, day, hour, ...) which already covers global time-range
+      queries, but guild/channel-scoped queries had to scan all rows in
+      the (event_name, day) range. Two compound indexes fix that.
+    - sessions: no PK at all, every query filters on started_date.
+    - voice_sessions: PK leads with channel_id, but every query filters
+      only on started_date — index it directly.
+    - dm_channels_data and guild_channels_data: PK is on channel_id, but
+      reads also group/filter by dm_user_id / guild_id respectively.
+    """
+    statements = [
+        'CREATE INDEX idx_activity_event_guild_day ON activity (event_name, associated_guild_id, day)',
+        'CREATE INDEX idx_activity_event_channel_day ON activity (event_name, associated_channel_id, day)',
+        'CREATE INDEX idx_sessions_started_date ON sessions (started_date)',
+        'CREATE INDEX idx_voice_sessions_started_date ON voice_sessions (started_date)',
+        'CREATE INDEX idx_dm_channels_dm_user_id ON dm_channels_data (dm_user_id)',
+        'CREATE INDEX idx_guild_channels_guild_id ON guild_channels_data (guild_id)',
+    ]
+    for stmt in statements:
+        cur.execute(stmt)
+
+
 def create_new_empty_database():
     conn = sqlite3.connect(':memory:')
     cur = conn.cursor()

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -23,7 +23,7 @@ from io import TextIOWrapper
 import gzip
 import tempfile
 
-from sqlite import create_new_empty_database, export_sqlite_to_bin
+from sqlite import create_new_empty_database, create_indexes, export_sqlite_to_bin
 
 import os
 from collections import defaultdict
@@ -900,6 +900,11 @@ def read_analytics_file(package_status_id, package_id, link, session):
         VALUES (?, ?, ?, ?, ?, ?, ?);
     ''', (package_id, '0.1.0',  user_data['id'], user_data['username'], user_data['display_name'], user_data['avatar_url'], 1 if is_partial else 0))
 
+    conn.commit()
+
+    # Build secondary indexes after bulk inserts but before VACUUM, so the
+    # vacuum repacks the index pages too.
+    create_indexes(cur)
     conn.commit()
 
     # make database smaller


### PR DESCRIPTION
## Summary

Closes #14.

The client-side SQLite database (the one shipped to the browser via \`/blob\`) had only PRIMARY KEYs on its tables. Common frontend reads — top guilds, top channels, top DMs, sending times, usage stats, etc. — were doing full table scans on the \`activity\` table (which can have 100k+ rows on heavy users) plus the \`sessions\` and \`voice_sessions\` tables (which had no usable index for their date-range filters at all).

## What's added

Six secondary indexes, built **after bulk insert** so each row only writes once, and **before \`VACUUM\`** so vacuum repacks the index pages too:

| Table | Index | Why |
|---|---|---|
| \`activity\` | \`(event_name, associated_guild_id, day)\` | Guild-scoped reads (use-guild-data, use-related-guild, top-guilds, top-channels filtered by guild) |
| \`activity\` | \`(event_name, associated_channel_id, day)\` | Channel-scoped reads (use-channel-data, use-dm-data, top-dms, top-channels) |
| \`sessions\` | \`(started_date)\` | Every \`sessions\` query in use-usage-stats-data filters on this; table had no PK |
| \`voice_sessions\` | \`(started_date)\` | Every \`voice_sessions\` query filters only on \`started_date\`; existing PK leads with \`channel_id\` |
| \`dm_channels_data\` | \`(dm_user_id)\` | Top-DM and DM-detail queries group/filter by this |
| \`guild_channels_data\` | \`(guild_id)\` | Guild-scoped channel listings filter by this |

The picks were validated against every \`SELECT\` in \`dumpus-app/src/hooks/data/use-*.ts\` and \`stores/database.ts\`. Patterns the existing PKs already covered (e.g. global \`event_name + day\` time-range scans hit the activity PK directly) didn't get a redundant index.

## Tradeoffs

- Slightly larger DB before \`gzip\` (indexes are repetitive, so they compress well — net size impact is small).
- Worker write time goes up marginally (one-shot index build over all activity rows). On the test heavy package, the build is well under a second.
- Frontend cold-start parse time is unchanged (sql.js doesn't lazy-load indexes).

## Test plan

- [ ] CI deploys; \`scripts/reprocess.sh\` against a real heavy package.
- [ ] Verify the resulting SQLite has the 6 indexes (\`SELECT name FROM sqlite_master WHERE type='index'\`).
- [ ] Open the package in the web app — every page that runs aggregation queries (Top Guilds, Top Channels, Top DMs, Usage Stats, Guild Detail, Channel Detail, DM Detail) should render the same data, just faster on heavy packages.