### PR TITLE
feat(api): cache /user upstream responses in postgres (24h TTL)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -8,7 +8,7 @@ from flask_limiter import Limiter
 # Import tasks before db so dotenv loads before SQLAlchemy reads POSTGRES_URL.
 import tasks
 from enqueue import enqueue_package
-from db import PackageProcessStatus, SavedPackageData, Session, fetch_package_status, fetch_package_rank
+from db import PackageProcessStatus, SavedPackageData, Session, fetch_package_status, fetch_package_rank, get_cached_discord_user, cache_discord_user
 
 from sqlite import generate_demo_database
 
@@ -291,13 +291,23 @@ def get_avatar(package_id, user_id):
             return make_response('', 401)
     
         session = Session()
-        data = fetch_package_status(package_id, session)
-        session.close()
+        try:
+            data = fetch_package_status(package_id, session)
 
-        if not data:
-            return make_response('', 401)
-        
-        user = fetch_diswho_user(user_id)
+            if not data:
+                return make_response('', 401)
+
+            # Hit the upstream only on a cache miss / stale entry. Then
+            # only persist responses that look real — username present
+            # is the cheapest signal that we got past auth/404/5xx and
+            # have something worth handing back to a future caller.
+            user = get_cached_discord_user(user_id, session)
+            if not user:
+                user = fetch_diswho_user(user_id)
+                if user and user.get('username'):
+                    cache_discord_user(user_id, user, session)
+        finally:
+            session.close()
 
         if not user:
             return make_response('', 500)

--- a/src/db.py
+++ b/src/db.py
@@ -1,9 +1,11 @@
 import os
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from sqlalchemy import create_engine, Column, Integer, String, DateTime, Boolean
 from sqlalchemy.orm import declarative_base, sessionmaker
 from sqlalchemy.sql import func, text
+
+import orjson
 
 engine = create_engine(os.getenv('POSTGRES_URL'), pool_recycle=3600, pool_pre_ping=True)
 
@@ -17,6 +19,24 @@ class SavedPackageData(Base):
     iv = Column(String(255), nullable=False)
     created_at = Column(DateTime, nullable=False, default=func.now())
     updated_at = Column(DateTime, nullable=False, onupdate=func.now(), default=func.now())
+
+class CachedDiscordUser(Base):
+    """Cache of upstream /user payloads (diswho or Discord bot API).
+
+    Discord usernames + avatars don't move often; the upstream is rate-
+    limited (429s on bursts) so a small Postgres-backed cache absorbs
+    the per-package fan-out and stops us hammering Discord every time
+    a user opens a heavy package.
+    """
+    __tablename__ = 'cached_discord_user'
+
+    user_id = Column(String(255), primary_key=True)
+    payload = Column(String, nullable=False)  # JSON-serialized upstream response
+    cached_at = Column(DateTime, nullable=False, default=func.now())
+
+
+CACHED_DISCORD_USER_TTL_HOURS = 24
+
 
 class PackageProcessStatus(Base):
     __tablename__ = 'package_process_status'
@@ -92,6 +112,33 @@ def fetch_package_rank (package_id, package_status, session):
 def fetch_package_status(package_id, session):
     status = session.query(PackageProcessStatus).filter_by(package_id=package_id).order_by(PackageProcessStatus.created_at.desc()).first()
     return status
+
+def get_cached_discord_user(user_id, session):
+    """Return the cached upstream user dict, or None if absent or stale."""
+    row = session.query(CachedDiscordUser).filter_by(user_id=user_id).first()
+    if not row:
+        return None
+    if datetime.now() - row.cached_at > timedelta(hours=CACHED_DISCORD_USER_TTL_HOURS):
+        return None
+    return orjson.loads(row.payload)
+
+
+def cache_discord_user(user_id, payload, session):
+    """Upsert a user payload into the cache.
+
+    Caller must only pass valid upstream responses — never None, never
+    error envelopes — so the cache doesn't pin failures and starve
+    legitimate retries.
+    """
+    serialized = orjson.dumps(payload).decode()
+    existing = session.query(CachedDiscordUser).filter_by(user_id=user_id).first()
+    if existing:
+        existing.payload = serialized
+        existing.cached_at = datetime.now()
+    else:
+        session.add(CachedDiscordUser(user_id=user_id, payload=serialized))
+    session.commit()
+
 
 def fetch_pending_packages():
     session = Session()


### PR DESCRIPTION
## Summary

Closes #13.

The \`/process/<package_id>/user/<user_id>\` endpoint was hitting diswho/Discord on every single call, with no caching. Heavy packages have hundreds of distinct user IDs, the upstream is rate-limited (429s on bursts), and the frontend's only mitigation is a 500 ms client-side throttle — so users routinely saw \`UNKNOWN_USER\` placeholders for some of their friends on first load.

## How it works

- New \`cached_discord_user\` table in Postgres (\`user_id\` PK, \`payload\` TEXT, \`cached_at\` timestamp). Auto-created on cold start via the existing \`Base.metadata.create_all\` pattern.
- \`get_cached_discord_user(user_id, session)\` returns the cached payload if it's younger than 24h, else \`None\`.
- \`cache_discord_user(user_id, payload, session)\` upserts. Caller is responsible for only passing valid payloads.
- The route handler now does: cache check → upstream on miss → write-through **only when** \`user.get('username')\` is truthy. So 4xx / 5xx / network failures are never pinned.

The \"only cache valid responses\" rule was the user-asked guard — failures shouldn't poison the cache and starve future legitimate retries.

## Why 24h TTL

Discord usernames and avatars rarely change. Worst case after a stale entry: one user sees a one-day-old display name until the next cache miss refreshes it. Could parameterize via env later if it becomes an issue.

## Trade-offs

- One extra Postgres round-trip on every \`/user\` hit (the cache lookup), but it's a PK lookup so essentially free.
- DB grows with unique user IDs across all packages. At our scale this is negligible (TEXT payload is ~200 bytes per row); if it ever matters, a periodic prune of rows older than 30 days is one cron line.
- No invalidation on Discord-side changes (rename / new avatar). Inherent to time-based caches; the 24h TTL bounds it.

## Test plan

- [ ] Merge → CI deploys.
- [ ] Hit \`/process/<package>/user/<known-id>\` for the first time, verify upstream call (CloudWatch).
- [ ] Hit it again, verify no upstream call (\`cached_discord_user\` row present, returned from cache).
- [ ] Hit \`/process/<package>/user/<bogus-id>\` (e.g. \`000000000000000000\`) — verify it returns 500 and the cache table has **no row** for that id.
- [ ] After ~24h, hit a known id again, verify upstream is consulted (cache refresh).