### PR TITLE
feat(worker): MISSING_USER_DATA error when user.json is absent

### DIFF
--- a/src/tasks.py
+++ b/src/tasks.py
@@ -209,14 +209,22 @@ def read_analytics_file(package_status_id, package_id, link, session):
         All this data will be useful to parse more complex things later.
         '''
 
-        user_path = find_user_root(zip.namelist())
-        if not user_path:
-            # Fallback to traditional paths
+        user_root = find_user_root(zip.namelist())
+        if user_root:
+            user_path = f'{user_root}/user.json'
+        elif 'Account/user.json' in zip.namelist():
             user_path = 'Account/user.json'
-            if user_path not in zip.namelist() and 'account/user.json' in zip.namelist():
-                user_path = 'account/user.json'
+        elif 'account/user.json' in zip.namelist():
+            user_path = 'account/user.json'
         else:
-            user_path = f'{user_path}/user.json'
+            # Discord exports drop user.json (and the entire Account folder)
+            # entirely when the user un-ticks the "User data" option in the
+            # request form. Without it the package has no owner identity to
+            # anchor the analysis on, so there's nothing useful to compute.
+            # Surface this as a distinct code so the UI can prompt them to
+            # re-export with that option enabled instead of bouncing them
+            # with the generic UNKNOWN_ERROR.
+            raise Exception('MISSING_USER_DATA')
         user_content = zip.open(user_path)
         user_json = orjson.loads(user_content.read())
         user_data = {
@@ -993,7 +1001,7 @@ def process_package(package_status_id, package_id, link, worker_name='regular_pr
         # just the string 'EXPIRED_LINK' (Python tuples need a comma);
         # the `in` check then accidentally did substring match on a
         # single code, hiding INVALID_LINK behind UNKNOWN_ERROR.
-        EXPECTED_ERROR_CODES = ('EXPIRED_LINK', 'INVALID_LINK')
+        EXPECTED_ERROR_CODES = ('EXPIRED_LINK', 'INVALID_LINK', 'MISSING_USER_DATA')
         current = str(e)
         e_traceback = None
         if current not in EXPECTED_ERROR_CODES:


### PR DESCRIPTION
## Summary

Two production packages today hit \`UNKNOWN_ERROR\` four times each before the user gave up retrying:

\`\`\`
KeyError: \"There is no item named 'Account/user.json' in the archive\"
  File \"/app/tasks.py\", line 220, in read_analytics_file
    user_content = zip.open(user_path)
\`\`\`

Root cause: Discord's export request form has a checkbox called **User data**. If the user un-ticks it, the export package ships **without** \`Account/user.json\` (or the localized equivalent). Our worker needs \`user.json\` for the package owner's identity (id, username, discriminator, avatar) — without it there's nothing meaningful to compute, so we should fail fast with a clear message rather than crash on a missing-key.

## What changed

- \`read_analytics_file\` now uses an explicit elif chain to find \`user.json\`. When \`find_user_root()\` and both legacy fallbacks (\`Account/user.json\`, \`account/user.json\`) all come up empty, raise \`MISSING_USER_DATA\` instead of falling through to a guaranteed KeyError.
- \`MISSING_USER_DATA\` added to the \`EXPECTED_ERROR_CODES\` tuple in \`process_package\` so it surfaces verbatim through the status endpoint instead of being relabeled \`UNKNOWN_ERROR\`.

No behavior change for packages that *do* have \`user.json\` — the code path resolves to the same \`user_path\` value.

## Frontend follow-up (separate PR)

The status response type in dumpus-app needs \`MISSING_USER_DATA\` added to the \`errorMessageCode\` union, plus a friendly copy string along the lines of:

> *Your Discord export didn't include your User data. When you request your data again, make sure the **User data** checkbox is ticked.*

Happy to open that PR right after this merges.

## Test plan

- [ ] Merge → CI deploys.
- [ ] No regression on packages that contain \`user.json\` (resolves to same code path).
- [ ] Submit a package without \`user.json\` (or wait for one of the affected users to retry) and verify the status endpoint returns \`isErrored: true, errorMessageCode: 'MISSING_USER_DATA'\`.