### PR TITLE
fix(worker): guard average-time print on compute_time list, not analytics_line_count

### DIFF
--- a/src/tasks.py
+++ b/src/tasks.py
@@ -433,11 +433,18 @@ def read_analytics_file(package_status_id, package_id, link, session):
             # package_is_partial from the SQLite to know which screens to
             # render as N/A. Asking the user to re-export would mean a
             # ~30-day round-trip, so degrading gracefully is the kinder UX.
-            if analytics_line_count > 0:
+            # Guard on compute_time_per_line, NOT analytics_line_count: the
+            # latter is bumped at the top of the loop, before the
+            # `if not 'event_type' in analytics_line_json: continue` skip.
+            # A file whose lines all lack event_type (Discord ships these
+            # for some kinds of partial exports) would have line count > 0
+            # but produce no usable events, which is the actual condition
+            # for "we have nothing to average and nothing to chart".
+            if compute_time_per_line:
                 is_partial = False
                 print(f'Average compute time per line: {sum(compute_time_per_line) / len(compute_time_per_line)}')
             else:
-                print('Analytics file is empty — keeping is_partial=True; activity-driven stats will be N/A on the client.')
+                print(f'Analytics file produced no usable events ({analytics_line_count} raw lines) — keeping is_partial=True; activity-driven stats will be N/A on the client.')
 
         print(f'Analytics data: {time.time() - start}')
         print(f'Session logs: {len(session_logs)}')


### PR DESCRIPTION
Follow-up to #81 — same package, still UNKNOWN_ERROR after the deploy at 08:07 UTC. New trace at 08:25 UTC, same line:

\`\`\`
File \"/app/tasks.py\", line 438, in read_analytics_file
    print(f'Average compute time per line: {sum(compute_time_per_line) / len(compute_time_per_line)}')
ZeroDivisionError: division by zero
\`\`\`

#81 used \`analytics_line_count > 0\` as the guard, which was the wrong condition. \`analytics_line_count\` is incremented at the **top** of the loop, before the \`if not 'event_type' in analytics_line_json: continue\` skip. So a file whose lines all lack \`event_type\` (the failing package's actual shape) has \`line_count > 0\` but \`compute_time_per_line == []\` — guard misses, divide blows up.

Real condition: \`if compute_time_per_line\`.

Behavior:

| File state | line_count | compute_time | old result | new result |
|---|---|---|---|---|
| Truly empty | 0 | [] | (#81) is_partial=True, OK | is_partial=True, OK |
| Lines, no `event_type` | >0 | [] | crash | is_partial=True, OK |
| Normal | >0 | >0 | is_partial=False, OK | is_partial=False, OK |

Auto-merging since the API is broken on this case in production right now.