### PR TITLE
fix(worker): skip Discord Orb payments in total spend

### DIFF
--- a/src/tasks.py
+++ b/src/tasks.py
@@ -257,8 +257,18 @@ def read_analytics_file(package_status_id, package_id, link, session):
         # 1 = SUCCESSFUL, 2 = FAILED, 3 = REFUNDED, 4 = REFUND_PENDING,
         # 5 = PARTIALLY_REFUNDED, 6 = PENDING. Without this filter, failed
         # and refunded charges inflate the "spent on Nitro" total.
+        #
+        # Also skip purchases settled in Discord Orbs (currency ==
+        # "discord_orb"). Orbs are a virtual currency Discord hands out via
+        # Quests / events — users do not pay real money to acquire them, and
+        # the `amount` is denominated in orbs, not cents. Summing them with
+        # fiat payments produced absurd totals (e.g. a user with €0 of real
+        # spend but ~30k orbs of cosmetic purchases got billed as "$297
+        # spent" because 29 720 orbs were treated as 29 720 cents).
         for payment in payment_records:
             if payment.get('status') != 1:
+                continue
+            if payment.get('currency') == 'discord_orb':
                 continue
             payments.append({
                 'id': payment['id'],


### PR DESCRIPTION
## Summary

A user reported `$297 spent` on an account that had spent €0 of real money. Their export's `payments.json` contained four status==1 entries, all with currency `discord_orb`:

| Description | Amount (orbs) |
|---|--:|
| Dark Roses Bundle | 11 000 |
| Kitsune Dream Bundle | 7 600 |
| Nevermore Bundle | 11 000 |
| Orbs Apprentice Badge | 120 |
| **Total** | **29 720** |

The status filter from #31 doesn't catch these — the orb purchases are genuinely SUCCESSFUL, just not denominated in fiat. The worker stored `amount=29720` with `currency="discord_orb"`, and the frontend sums `payment_amount` as cents regardless of currency, yielding `$297.20` (the reported `$297`).

Orbs are a virtual currency Discord awards via Quests / events; users don't buy them, so cosmetic purchases settled in orbs shouldn't count toward "money spent on Discord."

## Fix

Skip rows where `currency == 'discord_orb'` in the same loop as the status filter.

## Test plan

- [x] Reprocessing the reporter's package locally with the patch yields `$0 spent` (down from `$297.20`).
- [x] The three real-money USD rows in that same package were `status 2/5` (FAILED / PARTIALLY_REFUNDED) — already excluded by the existing status filter, no change in behavior for legitimate fiat payments.
- [ ] Re-run for an account with real Nitro spend to confirm fiat totals are untouched.